### PR TITLE
テストにおける nuxt-link の処理

### DIFF
--- a/spec/components/common/molecules/TheNavbarBrand.spec.js
+++ b/spec/components/common/molecules/TheNavbarBrand.spec.js
@@ -14,7 +14,7 @@ describe('components/common/molecules/TheTheNavbarBrand', () => {
     wrapper = mount(TheNavbarBrand, {
       localVue,
       stubs: {
-        RouterLink: RouterLinkStub
+        NuxtLink: RouterLinkStub
       }
     })
     content = id => `[data-test="${id}"]`

--- a/spec/components/common/organisms/TheHeader.spec.js
+++ b/spec/components/common/organisms/TheHeader.spec.js
@@ -1,6 +1,6 @@
 import Vuex from 'vuex'
 import Buefy from 'buefy'
-import { mount, createLocalVue } from '@vue/test-utils'
+import { mount, createLocalVue, RouterLinkStub } from '@vue/test-utils'
 import TheHeader from '~/components/common/organisms/TheHeader'
 
 const localVue = createLocalVue()
@@ -11,7 +11,12 @@ describe('components/common/organisms/TheHeader', () => {
   let wrapper
   let content
   beforeEach(() => {
-    wrapper = mount(TheHeader, { localVue })
+    wrapper = mount(TheHeader, {
+      localVue,
+      stubs: {
+        NuxtLink: RouterLinkStub
+      }
+    })
     content = id => `[data-test="${id}"]`
   })
 

--- a/spec/components/common/organisms/TheHeaderHard.spec.js
+++ b/spec/components/common/organisms/TheHeaderHard.spec.js
@@ -1,6 +1,6 @@
 import Vuex from 'vuex'
 import Buefy from 'buefy'
-import { mount, createLocalVue } from '@vue/test-utils'
+import { mount, createLocalVue, RouterLinkStub } from '@vue/test-utils'
 import TheHeaderHard from '~/components/common/organisms/TheHeaderHard'
 
 const localVue = createLocalVue()
@@ -10,7 +10,12 @@ localVue.use(Buefy)
 describe('components/common/organisms/TheHeaderHard', () => {
   let wrapper
   beforeEach(() => {
-    wrapper = mount(TheHeaderHard, { localVue })
+    wrapper = mount(TheHeaderHard, {
+      localVue,
+      stubs: {
+        NuxtLink: RouterLinkStub
+      }
+    })
   })
 
   describe('script', () => {


### PR DESCRIPTION
test-utils のライブラリをうまく使うといけるらしい

```
import { mount, RouterLinkStub } from '@vue/test-utils'

~~~

wrapper = mount(Hoge, {
  stubs: {
    NuxtLink: RouterLinkStub
  }
})
```